### PR TITLE
fix(issue18): Add configurable timeout and absorb transient errors for verification

### DIFF
--- a/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
+++ b/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
@@ -42,6 +42,9 @@ namespace AzAcme.Cli.Commands.Options
         [Option("force-order", HelpText = "Force order / renewal even if not expiring soon.")]
         public bool ForceOrder { get; set; } = false;
 
+        [Option("verification-timeout-seconds", Required = false, Default = 60, HelpText = "Challenge verification timout in seconds.")]
+        public int VerificationTimeoutSeconds { get; set; }
+        
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 

--- a/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
+++ b/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
@@ -42,7 +42,7 @@ namespace AzAcme.Cli.Commands.Options
         [Option("force-order", HelpText = "Force order / renewal even if not expiring soon.")]
         public bool ForceOrder { get; set; } = false;
 
-        [Option("verification-timeout-seconds", Required = false, Default = 60, HelpText = "Challenge verification timout in seconds.")]
+        [Option("verification-timeout-seconds",   Required = false, Default = 60, HelpText = "Challenge verification timout in seconds.")]
         public int VerificationTimeoutSeconds { get; set; }
         
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.

--- a/src/AzAcme.Cli/Program.cs
+++ b/src/AzAcme.Cli/Program.cs
@@ -94,6 +94,12 @@ namespace AzAcmi
                     throw new ConfigurationException("Error parsing Environment to Secret values. Exiting for safety.");
                 }
 
+                if (options.VerificationTimeoutSeconds < 30)
+                {
+                    logger.LogWarning("Overriding verification timeout to minimum value (30 seconds).");
+                    options.VerificationTimeoutSeconds = 30;
+                }
+
                 // Key Vault Certificates
                 logger.LogDebug("Creating Azure Key Vault certificate client...");
                 var kvCertificateClient = new CertificateClient(options.KeyVaultUri, azureCreds);


### PR DESCRIPTION
Fix issues relating to #18 by absorbing the known provider exception within the verification loop. Added configurable timeout period to allow extending of verification if required, same default as used previously (60 seconds).