### PR TITLE
fix(issue15): Update to add checks for the name of secrets and certificates

### DIFF
--- a/src/AzAcme.Cli/Commands/OrderCommand.cs
+++ b/src/AzAcme.Cli/Commands/OrderCommand.cs
@@ -1,6 +1,7 @@
 ﻿using AzAcme.Cli.Commands.Options;
 using AzAcme.Cli.Util;
 using AzAcme.Core;
+using AzAcme.Core.Exceptions;
 using AzAcme.Core.Extensions;
 using AzAcme.Core.Providers.Models;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,10 @@ namespace AzAcme.Cli.Commands
 
         protected override async Task<int> OnExecute(OrderOptions opts)
         {
+            // check the name is valid first.
+            await certificateStore.ValidateCertificateName(opts.Certificate);
+            
+            Console.WriteLine(opts.Certificate);
             var certificateRequest = new CertificateRequest(opts.Certificate, opts.Subject, opts.SubjectAlternativeNames);
 
             this.logger.LogInformation("Loading metadata from certificate store for certificate '{0}'.", opts.Certificate);

--- a/src/AzAcme.Core/ICertificateStore.cs
+++ b/src/AzAcme.Core/ICertificateStore.cs
@@ -4,6 +4,8 @@ namespace AzAcme.Core
 {
     public interface ICertificateStore
     {
+        Task ValidateCertificateName(string name);
+        
         Task<CertificateMetadata> GetMetadata(CertificateRequest request);
 
         Task<CertificateCsr> Prepare(CertificateRequest request);

--- a/src/AzAcme.Core/ISecretStore.cs
+++ b/src/AzAcme.Core/ISecretStore.cs
@@ -2,6 +2,8 @@
 {
     public interface ISecretStore
     {
+        Task ValidateSecretName(string name);
+        
         Task<IScopedSecret> CreateScopedSecret(string name);
     }
 }

--- a/src/AzAcme.Core/Providers/KeyVault/AzureKeyVaultCertificateStore.cs
+++ b/src/AzAcme.Core/Providers/KeyVault/AzureKeyVaultCertificateStore.cs
@@ -1,4 +1,6 @@
-﻿using AzAcme.Core.Providers.Models;
+﻿using System.Text.RegularExpressions;
+using AzAcme.Core.Exceptions;
+using AzAcme.Core.Providers.Models;
 using Azure;
 using Azure.Security.KeyVault.Certificates;
 using Microsoft.Extensions.Logging;
@@ -30,6 +32,17 @@ namespace AzAcme.Core.Providers.KeyVault
             return Task.FromResult(info);
         }
 
+        public Task ValidateCertificateName(string name)
+        {
+            const string regex = "^[A-Za-z0-9-]+$";
+
+            if (!Regex.IsMatch(name, regex))
+            {
+                throw new ConfigurationException($"Key Vault Certificate '{name}' invalid. Should be alphanumeric and dashes only.");
+            }
+            
+            return Task.CompletedTask;
+        }
         public async Task<CertificateCsr> Prepare(CertificateRequest request)
         {
             const string IssuerName = "Unknown"; // always same for externally managed lifecycles in azure.


### PR DESCRIPTION
Basic verification of the name to be alpha numeric or dash for certificate and secret names. See Issue #15 