### PR TITLE
fix `Invalid DNS Zone` caused by tailing newline characters

### DIFF
--- a/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
+++ b/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
@@ -21,17 +21,20 @@ namespace AzAcme.Cli.Commands.Options
         [Option("renew-within-days", Required = false, Default = 30, HelpText = "Renew within days before expiry.")]
         public int RenewWithinDays { get; set; }
 
+        private string _subject = "";
         [Option("subject", Required = true, HelpText = "Subject name of the certificate, such as 'foo.example.com'.")]
-        public string Subject { get; set; }
+        public string Subject { get => _subject; set { _subject = value.TrimEnd(new char[] { '\n', '\r' }); } }
 
         [Option("dns-provider", Required = true, Default = DnsProviders.Azure, HelpText = "DNS provider for challenges.")]
         public DnsProviders DnsProvider { get; set; }
 
+        private string _dnsZone = "";
         [Option("azure-dns-zone", Required = false, HelpText = "Resource ID for Azure DNS Zone to use for challenge.")]
-        public string DnsZoneResourceId { get; set; }
+        public string DnsZoneResourceId { get => _dnsZone; set { _dnsZone = value.TrimEnd(new char[] { '\n', '\r' }); } }
 
+        private string[] _sans;
         [Option("sans", Required = false, Separator = ' ', HelpText = "Subjet Alternative Names (SANs) space separated.")]
-        public IList<string> SubjectAlternativeNames { get; set; }
+        public IList<string> SubjectAlternativeNames { get => _sans; set { _sans = value.Select(v => v.TrimEnd(new char[] { '\n', '\r' })).ToArray(); } }
         
         [Option("aad-tenant", Required = false, HelpText = "Explicitly set AAD Tenant ID for obtaining JWT token for Azure DNS API.")]
         public string? AadTenantId { get; set; } = null;


### PR DESCRIPTION
It took me several hours to debug `Invalid DNS Zone` exception, and finally I realized that multi-line command in PowerShell attached a newline character to the value of `--azure-dns-zone`.

(It was the line ``--azure-dns-zone /subscriptions/********-****-****-****-************/resourceGroups/***/providers/Microsoft.Network/dnszones/***.com` `` that involves newline to `option.DnsZoneResourceId`
```
./az-acme.exe order `
>>         --server https://acme-v02.api.letsencrypt.org/directory `
>>         --key-vault-uri https://***.vault.azure.net/ `
>>         --certificate ***-acme-certificate `
>>         --subject "***.com" `
>>         --sans "1.***.com" `
>>         --account-secret ***-amce-registration `
>>         --dns-provider Azure `
>>         --azure-dns-zone /subscriptions/********-****-****-****-************/resourceGroups/***/providers/Microsoft.Network/dnszones/***.com` ###
>>         --renew-within-days 180 `
>>         --verbose
DBUG: Loading Azure Credentials from environment...
DBUG: Creating Azure Key Vault secret client...
DBUG: Creating Azure Key Vault certificate client...
DBUG: Creating ACME provider instance...
***-acme-certificate
INFO: Loading metadata from certificate store for certificate '***-acme-certificate'.
INFO: Certificate '***-acme-certificate' does not exist in the certificate store.
┌───────────────┬───────────────────────────┬──────────────┬────────┐
│ Subject       │ Subject Alternative Names │ Expiry (UTC) │ Action │
├───────────────┼───────────────────────────┼──────────────┼────────┤
│  ***.com      │    1.***.com              │ -            │ Order  │
└───────────────┴───────────────────────────┴──────────────┴────────┘
INFO: Obtaining credentials to ACME Provider from Azure Key Vault.
INFO: Initiating order to ACME provider.
INFO: Updating DNS challenge records.
DBUG: Getting DNS Client Token from AAD...
Invalid DNS Zone. All Subjects and SANs must be part of the same DNS Zone.
```