### PR TITLE
Use direct DNS query for challenge pre-validation

### DIFF
--- a/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
+++ b/src/AzAcme.Cli/Commands/Options/OrderOptions.cs
@@ -57,6 +57,10 @@ namespace AzAcme.Cli.Commands.Options
         [Option("cf-api-token", Required = false, HelpText = "Cloudflare API Token with permissions to modify DNS. Required when using Cloudflare DNS provider.")]
         public string CloudlfareApiToken { get; set; }
         
+
+        [Option("dns-lookup", Required = false, Default = "", HelpText = "DNS lookup server pre-defined name or custom IP address for challenge pre-validation.")]
+        public string DnsLookup { get; set; }
+        
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
 

--- a/src/AzAcme.Core/AzAcme.Core.csproj
+++ b/src/AzAcme.Core/AzAcme.Core.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.3.0" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.3.0" />
 		<PackageReference Include="Certes" Version="3.0.3" />
+		<PackageReference Include="DnsClient" Version="1.7.0" />
 		<PackageReference Include="Microsoft.Azure.Management.Dns" Version="3.0.1" />
 		<PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.38.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/AzAcme.Core/IDnsLookup.cs
+++ b/src/AzAcme.Core/IDnsLookup.cs
@@ -1,0 +1,9 @@
+﻿using AzAcme.Core.Providers.Models;
+
+namespace AzAcme.Core
+{
+    public interface IDnsLookup
+    {
+        Task<bool> ValidateTxtRecords(Order order);
+    }
+}

--- a/src/AzAcme.Core/Providers/DnsLookup.cs
+++ b/src/AzAcme.Core/Providers/DnsLookup.cs
@@ -1,0 +1,42 @@
+﻿using System.Net;
+using DnsClient;
+
+using AzAcme.Core.Providers.Helpers;
+using AzAcme.Core.Providers.Models;
+
+namespace AzAcme.Core.Providers
+{
+    public class DnsLookup : IDnsLookup
+    {
+        private readonly IPEndPoint? nameServer;
+
+        public DnsLookup() : this(null) { }
+
+        public DnsLookup(IPEndPoint? nameServer)
+        {
+            this.nameServer = nameServer;
+        }
+
+        public async Task<bool> ValidateTxtRecords(Order order)
+        {
+            bool dnsResolved = true;
+
+            var lookup = nameServer != null ? new LookupClient(nameServer) : new LookupClient();
+
+            foreach (var challenge in order.Challenges)
+            {
+                var dnsName = DnsHelpers.DetermineTxtRecordName(challenge.Identitifer, string.Empty);
+
+                var result = await lookup.QueryAsync(dnsName, QueryType.TXT);
+
+                if (!result.Answers.TxtRecords().SelectMany(x => x.Text).Contains(challenge.TxtValue))
+                {
+                    challenge.SetStatus(DnsChallenge.DnsChallengeStatus.Pending);
+                    dnsResolved = false;
+                }
+            }
+
+            return dnsResolved;
+        }
+    }
+}


### PR DESCRIPTION
It makes no sense to order challenge on ACME server while DNS record is being propagated thru DNS servers. Moreover such behavior causes premature failure of challenge on ACME server (e.g. Let's encrypt completes challenge with failure and begins responding with "Unable to update challenge :: authorization must be pending"). So it is better to previously wait while DNS challenge is being resolved in a right way before send validation request to ACME server.

So, I've added an option to "order" command named "dns-lookup" that may specify an IP address of DNS server to use. It also accepts some pre-defined values ("google" for 8.8.4.4, "google2" for 8.8.8.8, "cloudflare" for 1.1.1.1 and "cloudflare2" for 1.0.0.1). The option isn't required and if it isn't specified the local default DNS will be used.