### PR TITLE
Adds version number on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,10 +38,11 @@ jobs:
         shell: bash
         run: |
           tag=$(git describe --tags --abbrev=0)
+          tag_no_v=$(echo $tag | sed 's/v//g')
           release_name="cli-$tag-${{ matrix.target }}"
 
           # Build everything
-          dotnet publish src/AzAcme.Cli/AzAcme.Cli.csproj -p:PublishSingleFile=true --runtime "${{ matrix.target }}" -c Release -o "$release_name" --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true
+          dotnet publish src/AzAcme.Cli/AzAcme.Cli.csproj -p:PublishSingleFile=true --runtime "${{ matrix.target }}" -c Release -o "$release_name" --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true /p:Version="$tag_no_v"
 
           # Pack files
           if [ "${{ matrix.target }}" == "win-x64" ]; then


### PR DESCRIPTION
👋 Hey there! I noticed while using this tool that the `--version` wasn't outputting the correct version because it's not published with the correct property.

Current output:

```bash
❯ az-acme --version
az-acme 1.0.0
```

After this PR:

```bash
❯ az-acme --version
az-acme 0.4
```