### PR TITLE
Check Order State before checking DNS challenges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           release_name="cli-$tag-${{ matrix.target }}"
 
           # Build everything
-          dotnet publish src/AzAcme.Cli/AzAcme.Cli.csproj -p:PublishSingleFile=true --runtime "${{ matrix.target }}" -c Release -o "$release_name" --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true /p:Version="$tag_no_v"
+          dotnet publish src/AzAcme.Cli/AzAcme.Cli.csproj -p:PublishSingleFile=true --runtime "${{ matrix.target }}" -c Release -o "$release_name" --self-contained true -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true -p:Version="$tag_no_v"
 
           # Pack files
           if [ "${{ matrix.target }}" == "win-x64" ]; then

--- a/src/AzAcme.Core/Providers/CertesAcme/CertesAcmeProvider.cs
+++ b/src/AzAcme.Core/Providers/CertesAcme/CertesAcmeProvider.cs
@@ -139,6 +139,14 @@ namespace AzAcme.Core.Providers.CertesAcme
                 {
                     try
                     {
+                        var acmeOrder = (await certesOrder.Context.Resource()).Status;
+
+                        if (acmeOrder == Certes.Acme.Resource.OrderStatus.Ready)
+                        {
+                            challenge.SetStatus(DnsChallenge.DnsChallengeStatus.Validated);
+                            return order;
+                        }
+
                         var auth = await certesOrder.Context.Authorization(challenge.Identitifer);
                         await (await auth.Dns()).Validate();
 


### PR DESCRIPTION
- [x] Fix .NET publish script
- [x] Add order validation if order state is `Ready`

Great tool exactly what I was looking for when working with ACME and Azure!

But I've an issue when working with my company ACME server. In its ACME implementation, when using this tool it tries to check every single authorization `/acme/authz` for `Valid` state. However, my company's ACME server has slightly different implementation. When overall ACME order `/acme/order/{id}` becomes `Ready`, it's implied that `authorizations` are considered `Valid` and are not returned with the order.

Example of `/acme/order/{id}` response when is `Pending`:

```
{
   "status": "pending",
   "expires": "2024-04-16T17:58:11Z",
   "identifiers": [
      {
         "type": "dns",
         "value": "poc-api.dev.foo.bar"
      }
   ],
   "finalize": "https://acme.test.com/acme/finalize-order/8bAZtmax1H0mJSxWymgHP3dI-9v1YnuFN5ss65BDfjw",
   "authorizations": [
      "https://acme.test.com/acme/authz/T4cd12hUIuhU9gvL6YdivZd3sRB7pCUTK82AtndWOq8"
   ]

```

When Order is `Ready`:
```
{
   "status": "ready",
   "expires": "2024-04-16T17:58:11Z",
   "identifiers": [
      {
         "type": "dns",
         "value": "poc-api.dev.foo.bar"
      }
   ],
   "finalize": "https://acme.test.com/acme/finalize-order/8bAZtmax1H0mJSxWymgHP3dI-9v1YnuFN5ss65BDfjw",
   "authorizations": null
}
```

then all DNS challenges are considered validated and order can be finalized and cert retrieved.

My thinking here is that overall `/order` state can be prechecked (to look for `Ready` state) before checking each authorization `/authz` in more detail.

I've tested this on my private ACME server as well as Let's Encrypt ACME server.